### PR TITLE
Marco raise on blacklist on master pool

### DIFF
--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -14,11 +14,11 @@ module Makara
   autoload :Proxy,              'makara/proxy'
 
   module Errors
-    autoload :MakaraError,                'makara/errors/makara_error'
-    autoload :AllConnectionsBlacklisted,  'makara/errors/all_connections_blacklisted'
-    autoload :BlacklistConnection,        'makara/errors/blacklist_connection'
-    autoload :BlacklistConnectionOnMaster,     'makara/errors/blacklist_connection_on_master'
-    autoload :NoConnectionsAvailable,     'makara/errors/no_connections_available'
+    autoload :MakaraError,                  'makara/errors/makara_error'
+    autoload :AllConnectionsBlacklisted,    'makara/errors/all_connections_blacklisted'
+    autoload :BlacklistConnection,          'makara/errors/blacklist_connection'
+    autoload :BlacklistConnectionOnMaster,  'makara/errors/blacklist_connection_on_master'
+    autoload :NoConnectionsAvailable,       'makara/errors/no_connections_available'
   end
 
   module Logging

--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -17,6 +17,7 @@ module Makara
     autoload :MakaraError,                'makara/errors/makara_error'
     autoload :AllConnectionsBlacklisted,  'makara/errors/all_connections_blacklisted'
     autoload :BlacklistConnection,        'makara/errors/blacklist_connection'
+    autoload :BlacklistConnectionOnMaster,     'makara/errors/blacklist_connection_on_master'
     autoload :NoConnectionsAvailable,     'makara/errors/no_connections_available'
   end
 

--- a/lib/makara/errors/blacklist_connection_on_master.rb
+++ b/lib/makara/errors/blacklist_connection_on_master.rb
@@ -1,0 +1,14 @@
+module Makara
+  module Errors
+    class BlacklistConnectionOnMaster < MakaraError
+
+      attr_reader :original_error
+
+      def initialize(connection, error)
+        @original_error = error
+        super "[Makara/#{connection._makara_name}] master connection blacklisted (reraise on first error) #{error.message}."
+      end
+
+    end
+  end
+end

--- a/lib/makara/errors/blacklist_connection_on_master.rb
+++ b/lib/makara/errors/blacklist_connection_on_master.rb
@@ -1,6 +1,6 @@
 module Makara
   module Errors
-    class BlacklistConnectionOnMaster < MakaraError
+    class BlacklistConnectionOnMaster < NoConnectionsAvailable
 
       attr_reader :original_error
 

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -76,6 +76,7 @@ module Makara
         rescue Makara::Errors::BlacklistConnection => e
           errors.insert(0, e)
           con._makara_blacklist!
+          record_master_blacklist(e, con)
         end
       end
 
@@ -90,17 +91,27 @@ module Makara
       ret
     end
 
+    def handle_master_blacklists
+      if @just_blacklisted_master[Thread.current.object_id]
+        e = @just_blacklisted_master[Thread.current.object_id]
+        @just_blacklisted_master[Thread.current.object_id] = false
+        raise Makara::Errors::BlacklistConnectionOnMaster.new(@last_blacklisted_conn[Thread.current.object_id], e)
+      end
+    end
+
+    def record_master_blacklist(error, connection)
+      if self.role == "master"
+        @just_blacklisted_master[Thread.current.object_id] = error
+        @last_blacklisted_conn[Thread.current.object_id] = connection
+      end
+    end
     # Provide a connection that is not blacklisted and connected. Handle any errors
     # that may occur within the block.
     def provide
       provided_connection = self.next
       # nil implies that it's blacklisted
       if provided_connection
-        if @just_blacklisted_master[Thread.current.object_id]
-          e = @just_blacklisted_master[Thread.current.object_id]
-          @just_blacklisted_master[Thread.current.object_id] = false
-          raise Makara::Errors::BlacklistConnectionOnMaster.new(@last_blacklisted_conn[Thread.current.object_id], e)
-        end
+        handle_master_blacklists
         value = @proxy.error_handler.handle(provided_connection) do
           yield provided_connection
         end
@@ -122,10 +133,7 @@ module Makara
     rescue Makara::Errors::BlacklistConnection => e
       @blacklist_errors.insert(0, e)
       provided_connection._makara_blacklist!
-      if self.role == "master"
-        @just_blacklisted_master[Thread.current.object_id] = e
-        @last_blacklisted_conn[Thread.current.object_id] = provided_connection
-      end
+      record_master_blacklist(e, provided_connection)
       retry
     end
 

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -21,8 +21,8 @@ module Makara
       @blacklist_errors = []
       @disabled         = false
       @strategy         = proxy.strategy_for(role)
-      @just_black_listed_master = Hash.new nil
-      @last_blacklisted_conn = Hash.new nil
+      @just_black_listed_master = Hash.new
+      @last_blacklisted_conn = Hash.new
     end
 
 

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -21,7 +21,7 @@ module Makara
       @blacklist_errors = []
       @disabled         = false
       @strategy         = proxy.strategy_for(role)
-      @just_black_listed_master = Hash.new
+      @just_blacklisted_master = Hash.new
       @last_blacklisted_conn = Hash.new
     end
 
@@ -96,9 +96,9 @@ module Makara
       provided_connection = self.next
       # nil implies that it's blacklisted
       if provided_connection
-        if @just_black_listed_master[Thread.current.object_id]
-          e = @just_black_listed_master[Thread.current.object_id]
-          @just_black_listed_master[Thread.current.object_id] = false
+        if @just_blacklisted_master[Thread.current.object_id]
+          e = @just_blacklisted_master[Thread.current.object_id]
+          @just_blacklisted_master[Thread.current.object_id] = false
           raise Makara::Errors::BlacklistConnectionOnMaster.new(@last_blacklisted_conn[Thread.current.object_id], e)
         end
         value = @proxy.error_handler.handle(provided_connection) do
@@ -123,7 +123,7 @@ module Makara
       @blacklist_errors.insert(0, e)
       provided_connection._makara_blacklist!
       if self.role == "master"
-        @just_black_listed_master[Thread.current.object_id] = e
+        @just_blacklisted_master[Thread.current.object_id] = e
         @last_blacklisted_conn[Thread.current.object_id] = provided_connection
       end
       retry

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -94,7 +94,6 @@ module Makara
     # that may occur within the block.
     def provide
       provided_connection = self.next
-      # puts "Provide called"
       # nil implies that it's blacklisted
       if provided_connection
         $x = @proxy

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -113,13 +113,15 @@ module Makara
         raise Makara::Errors::NoConnectionsAvailable.new(@role) unless @disabled
       end
 
-    # when a connection causes a blacklist error within the provided block, we blacklist it then retry
+    # when a connection causes a blacklist error within the provided block, we blacklist it then retry unless we are using the master connection
     rescue Makara::Errors::BlacklistConnection => e
       @blacklist_errors.insert(0, e)
       provided_connection._makara_blacklist!
+      if self.role == "master"
+        raise e
+      end
       retry
     end
-
 
 
     protected

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -96,8 +96,6 @@ module Makara
       provided_connection = self.next
       # nil implies that it's blacklisted
       if provided_connection
-        $x = @proxy
-        $y = self
         if @just_black_listed_master
           e = @just_black_listed_master
           @just_black_listed_master = false


### PR DESCRIPTION
Fail first query when a master is blacklisted (allows app to detect a failed transaction).

Passes tests locally
```
marcomontagna@Marco-makara % rake spec

/Users/marcomontagna/.rbenv/versions/2.6.3/bin/ruby -I/Users/marcomontagna/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-support-3.9.3/lib:/Users/marcomontagna/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.2/lib /Users/marcomontagna/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.2/exe/rspec --pattern spec/\*\*/\*_spec.rb

Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 38579

Makara::ConnectionWrapper
  should invoke hijacked methods on the proxy when invoked directly
  should have a default weight of 1
  should extend the connection with new functionality
  #_makara_blacklisted?
    should handle frozen pre-epoch dates
    should store the blacklist status

Makara::ConfigParser
  should use provided proxy id instead of default
  should replace reserved characters and show a warning for provided proxy ids
  should provide a default proxy id based on the recursively sorted config
  master and slave configs
    should provide master and slave configs
    connection configuration should override makara config
  ::merge_and_resolve_default_url_config
    does nothing to a config without a url parameter
    parses the url parameter and merges it into the config
    does not use DATABASE_URL env variable

Makara::Middleware
  should set the cookie if master is used
  should init the context and not be stuck by default
  should use the cookie-provided context if present

Makara::Pool
  should determine if its completely blacklisted
  does not provide the same connection if the proxy is not sticky
  provides the same connection if the context has not changed and the proxy is sticky
  sends methods to all underlying objects if asked to
  skips blacklisted connections when choosing the next one
  only sends methods to underlying objects which are not blacklisted
  raises an error when all connections are blacklisted
  provides the next connection and blacklists
  should wrap connections with a ConnectionWrapper as theyre added to the pool

Makara::Strategies::PriorityFailover
  should take the top weight
  should use the strategy
  should take given order if no weights
  should handle failover to next one

ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler
  should raise the error
  should properly evaluate connection messages like: Can't connect to MySQL server on '123.456.789.235' (111)
  should properly evaluate connection messages like: Mysql2::Error Can't connect to MySQL server on '123.456.789.235' (111)
  should blacklist the connection
  should properly evaluate connection messages like: PG::ConnectionBad: PQsocket() can't get socket descriptor:
  should properly evaluate connection messages like: Mysql2::Error (Can't connect to MySQL server on '123.456.789.234' (111))
  should properly evaluate errors like: Mysql::Error: : INSERT INTO `watchers` (`user_id`, `watchable_id`, `watchable_type`) VALUES
  should properly evaluate connection messages like: PG::ConnectionBad: could not translate host name "some.sample.com" to address: Name or service not known
  should properly evaluate connection messages like: PG::ConnectionBad: timeout expired
  should properly evaluate connection messages like: Mysql2::Error: Lost connection to MySQL server during query: SELECT `geographies`.* FROM `geographies`
  should properly evaluate connection messages like: PG::AdminShutdown: FATAL:  terminating connection due to administrator command FATAL:  terminating connection due to administrator command
  should blacklist the connection
  should blacklist the connection
  should blacklist the connection
  should properly evaluate connection messages like: PGError: server closed the connection unexpectedly This probably me
  should blacklist the connection
  should blacklist the connection
  should properly evaluate connection messages like: PG::ConnectionBad: PQconsumeInput() SSL connection has been closed unexpectedly: SELECT  1 AS one FROM "users"  WHERE "users"."registration_ip" = '10.0.2.2' LIMIT 1
  should properly evaluate connection messages like: Mysql2::Error: closed MySQL connection: SELECT `users`.* FROM `users`
  should properly evaluate connection messages like: Mysql2::Error: Timeout waiting for a response from the last query
  should blacklist the connection
  should properly evaluate connection messages like: Could not connect to server: Connection refused Is the server running on host
  should blacklist the connection
  should blacklist the connection
  should properly evaluate connection messages like: Mysql2::Error: MySQL server has gone away: SELECT `users`.* FROM `users`
  should properly evaluate connection messages like: PG::ConnectionBad (could not connect to server: Connection refused
  should blacklist the connection
  should properly evaluate connection messages like: PG::UnableToSend: no connection to the server
  should properly evaluate connection messages like: org.postgresql.util.PSQLException: Connection to localhost:123 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
  should blacklist the connection
  should blacklist the connection
  should blacklist the connection
  should blacklist the connection
  should properly evaluate connection messages like: PG::ConnectionBad: FATAL: the database system is shutting down
  should raise the error
  should blacklist the connection
  should properly evaluate connection messages like: Mysql2::Error (Cannot connect to MySQL server on '123.456.789.234' (111))
  should blacklist the connection
  should properly evaluate errors like: PGError: ERROR: column items.user_id does not exist LINE 1: SELECT "items".* FROM "items" WHERE ("items".user_id = 4) OR
  should blacklist the connection
  should blacklist the connection
  should blacklist the connection
  should properly evaluate connection messages like: PG::ConnectionBad: FATAL: the database system is starting up
  should blacklist the connection
  custom errors
    identifies custom errors
    blacklists the connection

Makara::Cache
  shows a warning

MakaraMysql2Adapter
  with the connection established and schema loaded
    should have one master and two slaves
    should send exists? to slave
    should send SET operations to each connection
    should send writes to master
    should allow reconnecting
    should send reads to the slave
    should allow reconnecting when one of the nodes is blacklisted
    should blacklist on timeout
    should allow real queries to work
  unconnected
    should execute a send_to_all and raise a NoConnectionsAvailable error
    should allow a connection to be established
    should execute a send_to_all against master even if no slaves are connected
    unconnect afterwards
      should not blow up if a connection fails
  transaction support
    when sticky is true
      behaves like a transaction supporter
        when executing a query
          should respect the transaction
        when querying for a specific record
          should respect the transaction
        when querying an aggregate
          should respect the transaction
        when querying through a polymorphic relation
          should respect the transaction
    when sticky is false
      behaves like a transaction supporter
        when querying through a polymorphic relation
          should respect the transaction
        when querying for a specific record
          should respect the transaction
        when querying an aggregate
          should respect the transaction
        when executing a query
          should respect the transaction

MakaraPostgreSQLAdapter
  should allow a connection to be established
  with the connection established and schema loaded
    should send reads to the slave
    should have one master and two slaves
    should send writes to master
    should allow real queries to work
    should send SET operations to each connection
    should send exists? to slave
  with only slave connection
    should raise error only on write
  transaction support
    when sticky is false
      behaves like a transaction supporter
        when querying for a specific record
          should respect the transaction
        when executing a query
          should respect the transaction
        when querying an aggregate
          should respect the transaction
        when querying through a polymorphic relation
          should respect the transaction
    when sticky is true
      behaves like a transaction supporter
        when executing a query
          should respect the transaction
        when querying for a specific record
          should respect the transaction
        when querying an aggregate
          should respect the transaction
        when querying through a polymorphic relation
          should respect the transaction
  with only master connection
    should not raise errors on read and write
  without live connections
    should raise errors on read or write

Makara::Context
  does not share stickiness state across threads
  next
    doesn't update previously stored proxies if the update will cause a sooner expiration
    returns nil if there is nothing new to stick
    doesn't store staged proxies with 0 stickiness duration
    returns hash with updated stickiness
    sets expiration time with ttl based on the invokation time
    clears expired entries for proxies that are no longer stuck
  stick
    uses always the max ttl given
    supports floats as ttl
    doesn't overwrite previously stuck proxies with current-request-only stickiness
    sticks a proxy to master for the current request
  set_current
    sets stickiness information from given hash
  release_all
    does nothing if there were no stuck proxies
    clears stickiness for all stuck proxies
  release
    does nothing if the proxy given was not stuck
    clears stickiness for the given proxy

Makara::Proxy
  instantiates N connections within each pool
  should delegate any unknown method to a connection in the master pool
  sets up a master and slave pool no matter the number of connections
  #stick_to_master
    should use master if manually forced
    supports a float master_ttl for stickiness duration
    optionally skips stickiness persistence, so it applies only to the current request
    should persist stickiness by default
  #appropriate_pool
    should provide the slave pool for a read
    should provide the master pool for a write
    should use master if all slaves become blacklisted as part of the invocation
    should not stick to master if we are in a without_sticking block
    should not stick to master if stickiness is disabled
    should use master if all slaves are blacklisted
    should not stick to master after without_sticking block if there is a write in it
    should release master if all stuck connections are released
    should raise the error and whitelist all connections if everything is blacklisted (start over)
    should stick to master once used for a sticky operation
    should be sticky by default
    should not release master if it was stuck in the same request (no context changes yet)

Makara::Strategies::RoundRobin
  should handle failover to next one
  should loop through with weights
  given in config
    should use the strategy
  default config
    should default to the strategy
  bad config
    should raise name error

ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter
  determines that "    select * from users for update" requires master
  determines that "rollback" requires master
  determines that "select get_lock('foo', 0)" requires master
  should not stick to master if handling sql like "show tables"
  determines that "select * from felines" does not require master
  should not stick to master if handling sql like "show views"
  should not stick to master if handling sql like "set @@things"
  determines that "savepoint active_record_1" requires master
  determines that "    select * from felines" does not require master
  should not stick to master if handling sql like "show full tables"
  determines that "select * from users lock in share mode" requires master
  should not stick to master if handling sql like "explain things"
  should not stick to master if handling sql like "show database"
  should stick to master if handling sql like "begin transaction"
  determines that "describe table" requires master
  determines that "select * from users where name = "for update"" does not require master
  determines that "with fence as (select * from users) select * from fence" does not require master
  should not stick to master if handling sql like "show table"
  should stick to master if handling sql like "commit transaction"
  determines that "INSERT INTO wisdom ('The truth will set you free.')" should not be sent to all underlying connections
  should stick to master if handling sql like "
      UPDATE
        dogs
      SET
        max_treats = 10
      WHERE
        max_treats IS NULL
    "
  determines that "select lastval()" requires master
  determines that "insert into dogs..." requires master
  determines that "with fence as (select * from felines) insert to cats" requires master
  determines that "INSERT INTO wisdom ('The truth will
set you free.')" should not be sent to all underlying connections
  determines that "select pg_advisory_unlock(12345)" requires master
  determines that "begin" requires master
  determines that "show index" requires master
  determines that "select nextval('users_id_seq')" requires master
  should not stick to master if handling sql like "show full table"
  determines that "show tables" requires master
  should stick to master if handling sql like "insert into"
  determines that "show fields" requires master
  determines that "release savepoint" requires master
  determines that "
      UPDATE
        dogs
      SET
        max_treats = 10
      WHERE
        max_treats IS NULL
    " should not be sent to all underlying connections
  determines that "delete from people" requires master
  determines that "update users set" requires master
  should not stick to master if handling sql like "show view"
  should not stick to master if handling sql like "show index"
  determines that "insert into cats (select * from felines)" requires master
  determines that "select pg_advisory_lock(12345)" requires master
  determines that "SET @@things" requires master
  should not stick to master if handling sql like "show schema"
  should stick to master if handling sql like "delete from"
  determines that "select release_lock('foo')" requires master
  determines that "set @@things" requires master
  should stick to master if handling sql like "update users"
  determines that "select currval('users_id_seq')" requires master
  determines that "SET @@things" should be sent to all underlying connections
  determines that "commit" requires master
  determines that "UPDATE dogs SET max_treats = 10 WHERE max_treats IS NULL" should not be sent to all underlying connections
  should not stick to master if handling sql like "show indexes"
  determines that "select * from users for update" requires master
  determines that "select * from users where name = "lock in share mode"" does not require master
  should stick to master if handling sql like "rollback transaction"
  should stick to master if handling sql like "begin deferred transaction"
  should not stick to master if handling sql like "describe stuff"

Makara::Cookie
  store
    expires the cookie if the next context is empty
    sets the context cookie with updated stickiness and enough expiration time
    allows custom cookie options to be provided
    does not set a cookie if there is no next context
  fetch
    parses stickiness context from cookie string
    returns empty context data when there is no cookie
    returns empty context data when the cookie contents are invalid

Finished in 14.58 seconds (files took 0.89331 seconds to load)
219 examples, 0 failures

Randomized with seed 38579
```